### PR TITLE
Add GitHub Skills activity to extracurricular activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -21,6 +21,12 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 
 # In-memory activity database
 activities = {
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub's certification program",
+        "schedule": "Mondays and Wednesdays, 3:00 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",


### PR DESCRIPTION
This PR adds the GitHub Skills activity that was announced by the principal. The activity will help students earn GitHub certifications and improve their college applications.

## Changes
- Added GitHub Skills activity to the activities dictionary
- Set schedule for Mondays and Wednesdays
- Added capacity for 25 participants
- Included description mentioning the certification program

## Testing
The activity will appear in the activities list and students can sign up through the existing endpoints:
- View activity: GET `/activities`
- Sign up: POST `/activities/GitHub Skills/signup?email=student@mergington.edu`

Fixes #6